### PR TITLE
adding a function to retrieve all earning results for a particular stock

### DIFF
--- a/yahoo_earnings_calendar/scraper.py
+++ b/yahoo_earnings_calendar/scraper.py
@@ -32,6 +32,22 @@ class YahooEarningsCalendar(object):
         page_data_string = page_data_string.split('root.App.main = ', 1)[1]
         return json.loads(page_data_string)
 
+    def get_all_earnings(self, symbol):
+        """Gets all earning dates of a symbol
+        Args:
+            symbol: A ticker symbol
+        Returns:
+            A list of dictionaries containing details for all available earnings
+        Raises:
+            Exception: When symbol is invalid or earnings date is not available
+        """
+        url = f'{BASE_URL}?symbol={symbol}'
+        try:
+            page_data_dict = self._get_data_dict(url)
+            return page_data_dict['context']['dispatcher']['stores']['ScreenerResultsStore']['results']['rows']
+        except:
+            raise Exception('Invalid Symbol')
+
     def get_next_earnings_date(self, symbol):
         """Gets the next earnings date of symbol
         Args:
@@ -129,3 +145,4 @@ if __name__ == '__main__': # pragma: no cover
     print(yec.earnings_between(date_from, date_to))
     # Returns the next earnings date of BOX in Unix timestamp
     print(yec.get_next_earnings_date('box'))
+    print(yec.get_all_earnings('intc'))


### PR DESCRIPTION
Hey  @wenboyu2 , 
since i was interested in retrieving past dates for earnings, I've added a new function that does this. 

It will return a list of dictionaries containing the information on all available earnings available on yahoo. 
Basically the table you see on -> https://finance.yahoo.com/calendar/earnings?symbol=intc