### PR TITLE
Adding custom user-agent, bypass Yahoo's block

### DIFF
--- a/yahoo_earnings_calendar/scraper.py
+++ b/yahoo_earnings_calendar/scraper.py
@@ -33,7 +33,7 @@ class YahooEarningsCalendar(object):
 
     def _get_data_dict(self, url):
         time.sleep(self.delay)
-        page = requests.get(url)
+        page = requests.get(url, headers={'User-Agent': 'Custom'})
         page_content = page.content.decode(encoding='utf-8', errors='strict')
         page_data_string = [row for row in page_content.split(
             '\n') if row.startswith('root.App.main = ')][0][:-1]


### PR DESCRIPTION
It seems like Yahoo blocked python user agent. Changing the agent to "custom" seems to fix it.